### PR TITLE
Test on FreeBSD by using serverspec

### DIFF
--- a/test/integration/default/bats/verify_default.bats
+++ b/test/integration/default/bats/verify_default.bats
@@ -1,3 +1,0 @@
-@test "check for zsh command" {
-  which zsh
-}

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,6 @@
+require 'serverspec'
+set :backend, :exec
+
+describe command('which zsh') do
+  its(:exit_status) { should eq 0 }
+end


### PR DESCRIPTION
bats requires bash which doesn't ship on freebsd out of the box